### PR TITLE
Fix bias page layout and search filtering

### DIFF
--- a/bias.html
+++ b/bias.html
@@ -15,7 +15,9 @@
   </nav>
 
   <div class="container my-4">
-    <div id="bias-content"><p>Загрузка...</p></div>
+    <div class="row justify-content-center">
+      <div class="col-12 col-md-8" id="bias-content"><p>Загрузка...</p></div>
+    </div>
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
@@ -38,7 +40,7 @@
           }
 
           const trueId = bias.biasId - 100;
-          const {title, shortDescription, fullDescription, category, wikipediaLink, content = {}} = bias;
+          const {title, shortDescription, fullDescription, wikipediaLink, content = {}} = bias;
           const {examples = [], advices = []} = content;
 
           // Разбиваем fullDescription на абзацы
@@ -47,7 +49,6 @@
 
           let html = `
             <h1 class="mb-3">${trueId}. ${title}</h1>
-            ${category ? `<span class="badge mb-3">${category}</span>` : ''}
             ${shortDescription ? `<p class="fs-5 mb-4">${shortDescription}</p>` : ''}`;
 
           if (examples.length) {
@@ -61,9 +62,8 @@
           }
 
           if (advices.length) {
-            html += '<h3 class="mt-4">Советы</h3><ul>';
-            advices.forEach(a => html += `<li>${a}</li>`);
-            html += '</ul>';
+            html += '<h3 class="mt-4">Советы</h3>';
+            advices.forEach(a => html += `<div class="advice mb-2">${a}</div>`);
           }
 
           if (wikipediaLink) {

--- a/index.html
+++ b/index.html
@@ -41,7 +41,7 @@
         data.forEach(bias => {
           const trueId = bias.biasId - 100;
           const col = document.createElement('div');
-          col.className = 'col-12'; // один столбик
+          col.className = 'col-12 bias-col';
           col.innerHTML = `
             <div class="card h-100" data-title="${bias.title.toLowerCase()}">
               <div class="card-body">
@@ -56,10 +56,11 @@
         // Поиск
         searchInput.addEventListener('input', () => {
           const q = searchInput.value.toLowerCase().trim();
-          const cards = listEl.querySelectorAll('.card');
-          cards.forEach(card => {
+          const cols = listEl.querySelectorAll('.bias-col');
+          cols.forEach(col => {
+            const card = col.querySelector('.card');
             const title = card.dataset.title;
-            card.classList.toggle('hidden', !title.includes(q));
+            col.classList.toggle('hidden', !title.includes(q));
           });
         });
       })

--- a/style.css
+++ b/style.css
@@ -58,6 +58,12 @@ a:hover {
 }
 
 /* Smooth fade for hidden cards */
-.card.hidden {
+.bias-col.hidden {
   display: none !important;
+}
+
+.advice {
+  background-color: #e9ecef;
+  border-radius: .5rem;
+  padding: .75rem 1rem;
 }


### PR DESCRIPTION
## Summary
- hide entire columns when filtering search results so there are no gaps
- support custom column class in styles
- narrow cognitive bias page to an 8-column layout
- drop category display and show advice in a highlighted box

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6864097a92208327a68db5d7245bc096