### PR TITLE
Add language selector for biases pages

### DIFF
--- a/bias.html
+++ b/bias.html
@@ -11,6 +11,12 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
       <a class="navbar-brand" href="index.html">Когнитивные искажения</a>
+      <div class="d-flex ms-auto align-items-center">
+        <select id="languageSelect" class="form-select me-2" style="width:auto">
+          <option value="ru">Русский</option>
+          <option value="en">English</option>
+        </select>
+      </div>
     </div>
   </nav>
 
@@ -24,34 +30,77 @@
   <script>
     const params = new URLSearchParams(window.location.search);
     const biasIdParam = parseInt(params.get('biasId'), 10);
+    const langSelect = document.getElementById('languageSelect');
+    const locale = localStorage.getItem('lang') || 'ru';
+    langSelect.value = locale;
+    document.documentElement.lang = locale;
+
+    const texts = {
+      ru: {
+        brand: 'Когнитивные искажения',
+        loading: 'Загрузка...',
+        noId: 'Не указан BIAS ID.',
+        notFound: 'Искажение не найдено.',
+        error: 'Ошибка загрузки данных.',
+        wiki: 'Статья в Википедии',
+        examples: 'Примеры',
+        more: 'Подробнее',
+        advices: 'Советы'
+      },
+      en: {
+        brand: 'Cognitive biases',
+        loading: 'Loading...',
+        noId: 'BIAS ID is missing.',
+        notFound: 'Bias not found.',
+        error: 'Failed to load data.',
+        wiki: 'Wikipedia article',
+        examples: 'Examples',
+        more: 'More details',
+        advices: 'Advice'
+      }
+    };
+
+    function applyTexts() {
+      const t = texts[locale];
+      document.querySelector('.navbar-brand').textContent = t.brand;
+      document.getElementById('bias-content').innerHTML = `<p>${t.loading}</p>`;
+    }
+
+    applyTexts();
+
+    langSelect.addEventListener('change', () => {
+      localStorage.setItem('lang', langSelect.value);
+      location.reload();
+    });
 
     function getBiases() {
-      const cached = localStorage.getItem('biasData');
+      const cacheKey = `biasData_${locale}`;
+      const cached = localStorage.getItem(cacheKey);
       if (cached) {
         try {
           return Promise.resolve(JSON.parse(cached));
         } catch (e) {
-          localStorage.removeItem('biasData');
+          localStorage.removeItem(cacheKey);
         }
       }
-      return fetch('https://api.lutai.ru/api/biases?pagination[limit]=300&locale=ru')
+      return fetch(`https://api.lutai.ru/api/biases?pagination[limit]=300&locale=${locale}`)
         .then(r => r.json())
         .then(({data}) => {
-          localStorage.setItem('biasData', JSON.stringify(data));
+          localStorage.setItem(cacheKey, JSON.stringify(data));
           return data;
         });
     }
 
     if (!biasIdParam) {
       document.getElementById('bias-content').innerHTML =
-        '<p class="text-danger">Не указан BIAS ID.</p>';
+        `<p class="text-danger">${texts[locale].noId}</p>`;
     } else {
       getBiases()
         .then(data => {
           const bias = data.find(b => b.biasId === biasIdParam);
           if (!bias) {
             document.getElementById('bias-content').innerHTML =
-              '<p class="text-danger">Искажение не найдено.</p>';
+              `<p class="text-danger">${texts[locale].notFound}</p>`;
             return;
           }
 
@@ -68,29 +117,29 @@
             ${shortDescription ? `<p class="fs-5 mb-4">${shortDescription}</p>` : ''}`;
 
           if (examples.length) {
-            html += '<h3 class="mt-3">Примеры</h3><ul>';
+            html += `<h3 class="mt-3">${texts[locale].examples}</h3><ul>`;
             examples.forEach(e => html += `<li>${e}</li>`);
             html += '</ul>';
           }
 
           if (paragraphs) {
-            html += '<h3 class="mt-4">Подробнее</h3>' + paragraphs;
+            html += `<h3 class="mt-4">${texts[locale].more}</h3>` + paragraphs;
           }
 
           if (advices.length) {
-            html += '<h3 class="mt-4">Советы</h3>';
+            html += `<h3 class="mt-4">${texts[locale].advices}</h3>`;
             advices.forEach(a => html += `<div class="advice mb-2">${a}</div>`);
           }
 
           if (wikipediaLink) {
-            html += `<p class="mt-4"><a href="${wikipediaLink}" target="_blank" rel="noopener">Статья в Википедии</a></p>`;
+            html += `<p class="mt-4"><a href="${wikipediaLink}" target="_blank" rel="noopener">${texts[locale].wiki}</a></p>`;
           }
 
           document.getElementById('bias-content').innerHTML = html;
         })
         .catch(() => {
           document.getElementById('bias-content').innerHTML =
-            '<p class="text-danger">Ошибка загрузки данных.</p>';
+            `<p class="text-danger">${texts[locale].error}</p>`;
         });
     }
   </script>

--- a/index.html
+++ b/index.html
@@ -14,9 +14,15 @@
   <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
     <div class="container">
       <a class="navbar-brand" href="#">Когнитивные искажения</a>
-      <form class="d-flex ms-auto" role="search">
-        <input id="searchInput" class="form-control" type="search" placeholder="Поиск..." aria-label="Поиск">
-      </form>
+      <div class="d-flex ms-auto align-items-center">
+        <select id="languageSelect" class="form-select me-2" style="width:auto">
+          <option value="ru">Русский</option>
+          <option value="en">English</option>
+        </select>
+        <form class="d-flex" role="search">
+          <input id="searchInput" class="form-control" type="search" placeholder="Поиск..." aria-label="Поиск">
+        </form>
+      </div>
     </div>
   </nav>
 
@@ -32,20 +38,54 @@
   <script>
     const searchInput = document.getElementById('searchInput');
     const listEl = document.getElementById('bias-list');
+    const langSelect = document.getElementById('languageSelect');
+    const locale = localStorage.getItem('lang') || 'ru';
+    langSelect.value = locale;
+    document.documentElement.lang = locale;
+
+    const texts = {
+      ru: {
+        brand: 'Когнитивные искажения',
+        heading: 'Список когнитивных искажений',
+        search: 'Поиск...',
+        error: 'Не удалось загрузить данные. Попробуйте позже.'
+      },
+      en: {
+        brand: 'Cognitive biases',
+        heading: 'List of cognitive biases',
+        search: 'Search...',
+        error: 'Failed to load data. Please try again later.'
+      }
+    };
+
+    function applyTexts() {
+      const t = texts[locale];
+      document.querySelector('.navbar-brand').textContent = t.brand;
+      document.querySelector('h1').textContent = t.heading;
+      searchInput.placeholder = t.search;
+    }
+
+    applyTexts();
+
+    langSelect.addEventListener('change', () => {
+      localStorage.setItem('lang', langSelect.value);
+      location.reload();
+    });
 
     function getBiases() {
-      const cached = localStorage.getItem('biasData');
+      const cacheKey = `biasData_${locale}`;
+      const cached = localStorage.getItem(cacheKey);
       if (cached) {
         try {
           return Promise.resolve(JSON.parse(cached));
         } catch (e) {
-          localStorage.removeItem('biasData');
+          localStorage.removeItem(cacheKey);
         }
       }
-      return fetch('https://api.lutai.ru/api/biases?pagination[limit]=300&locale=ru')
+      return fetch(`https://api.lutai.ru/api/biases?pagination[limit]=300&locale=${locale}`)
         .then(r => r.json())
         .then(({data}) => {
-          localStorage.setItem('biasData', JSON.stringify(data));
+          localStorage.setItem(cacheKey, JSON.stringify(data));
           return data;
         });
     }
@@ -81,7 +121,7 @@
         });
       })
       .catch(() => {
-        listEl.innerHTML = '<p class="text-danger">Не удалось загрузить данные. Попробуйте позже.</p>';
+        listEl.innerHTML = `<p class="text-danger">${texts[locale].error}</p>`;
       });
   </script>
 </body>

--- a/style.css
+++ b/style.css
@@ -19,6 +19,12 @@ html, body {
   padding-left: 1.25rem;
 }
 
+#languageSelect {
+  width: auto;
+  min-width: 110px;
+  margin-right: 0.5rem;
+}
+
 /* Cards */
 .card {
   border: none;


### PR DESCRIPTION
## Summary
- add language selector to both pages
- fetch bias data based on selected locale and cache per language
- translate a few interface labels when locale is English
- style the language selector

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68640bc9ecac832797f0d186c30943b9