### PR TITLE
Fix quiz question display and show explanations

### DIFF
--- a/bias.html
+++ b/bias.html
@@ -12,6 +12,7 @@
     <div class="container">
       <a class="navbar-brand" href="index.html">Когнитивные искажения</a>
       <div class="d-flex ms-auto align-items-center">
+        <a id="trainingLink" href="training.html" class="btn btn-outline-light me-2">Тренировка</a>
         <select id="languageSelect" class="form-select me-2" style="width:auto">
           <option value="ru">Русский</option>
           <option value="en">English</option>
@@ -45,7 +46,8 @@
         wiki: 'Статья в Википедии',
         examples: 'Примеры',
         more: 'Подробнее',
-        advices: 'Советы'
+        advices: 'Советы',
+        training: 'Тренировка'
       },
       en: {
         brand: 'Cognitive biases',
@@ -56,7 +58,8 @@
         wiki: 'Wikipedia article',
         examples: 'Examples',
         more: 'More details',
-        advices: 'Advice'
+        advices: 'Advice',
+        training: 'Training'
       }
     };
 
@@ -64,6 +67,7 @@
       const t = texts[locale];
       document.querySelector('.navbar-brand').textContent = t.brand;
       document.getElementById('bias-content').innerHTML = `<p>${t.loading}</p>`;
+      document.getElementById('trainingLink').textContent = t.training;
     }
 
     applyTexts();

--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
     <div class="container">
       <a class="navbar-brand" href="#">Когнитивные искажения</a>
       <div class="d-flex ms-auto align-items-center">
+        <a id="trainingLink" href="training.html" class="btn btn-outline-light me-2">Тренировка</a>
         <select id="languageSelect" class="form-select me-2" style="width:auto">
           <option value="ru">Русский</option>
           <option value="en">English</option>
@@ -48,12 +49,14 @@
         brand: 'Когнитивные искажения',
         heading: 'Список когнитивных искажений',
         search: 'Поиск...',
+        training: 'Тренировка',
         error: 'Не удалось загрузить данные. Попробуйте позже.'
       },
       en: {
         brand: 'Cognitive biases',
         heading: 'List of cognitive biases',
         search: 'Search...',
+        training: 'Training',
         error: 'Failed to load data. Please try again later.'
       }
     };
@@ -63,6 +66,7 @@
       document.querySelector('.navbar-brand').textContent = t.brand;
       document.querySelector('h1').textContent = t.heading;
       searchInput.placeholder = t.search;
+      document.getElementById('trainingLink').textContent = t.training;
     }
 
     applyTexts();

--- a/training.html
+++ b/training.html
@@ -1,0 +1,184 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+  <meta charset="utf-8">
+  <title>Тренировка</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="style.css" rel="stylesheet">
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <div class="container">
+      <a class="navbar-brand" href="index.html">Когнитивные искажения</a>
+      <div class="d-flex ms-auto align-items-center">
+        <select id="languageSelect" class="form-select me-2" style="width:auto">
+          <option value="ru">Русский</option>
+          <option value="en">English</option>
+        </select>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container my-4">
+    <h1 class="mb-4" id="pageTitle">Тренировка</h1>
+    <div id="quiz" class="card p-4">
+      <h4 id="questionText" class="mb-3">...</h4>
+      <div id="answers" class="mt-3 d-grid gap-2"></div>
+      <p id="explanation" class="mt-3"></p>
+      <button id="nextBtn" class="btn btn-primary mt-3 d-none">Следующий вопрос</button>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const languageSelect = document.getElementById('languageSelect');
+    const locale = localStorage.getItem('lang') || 'ru';
+    languageSelect.value = locale;
+    document.documentElement.lang = locale;
+
+    const texts = {
+      ru: {
+        brand: 'Когнитивные искажения',
+        title: 'Тренировка',
+        next: 'Следующий вопрос',
+        loadError: 'Ошибка загрузки данных.'
+      },
+      en: {
+        brand: 'Cognitive biases',
+        title: 'Training',
+        next: 'Next question',
+        loadError: 'Failed to load data.'
+      }
+    };
+
+    function applyTexts() {
+      const t = texts[locale];
+      document.querySelector('.navbar-brand').textContent = t.brand;
+      document.getElementById('pageTitle').textContent = t.title;
+      document.getElementById('nextBtn').textContent = t.next;
+    }
+
+    applyTexts();
+
+    languageSelect.addEventListener('change', () => {
+      localStorage.setItem('lang', languageSelect.value);
+      location.reload();
+    });
+
+    function getBiases() {
+      const cacheKey = `biasData_${locale}`;
+      const cached = localStorage.getItem(cacheKey);
+      if (cached) {
+        try {
+          return Promise.resolve(JSON.parse(cached));
+        } catch (e) {
+          localStorage.removeItem(cacheKey);
+        }
+      }
+      return fetch(`https://api.lutai.ru/api/biases?pagination[limit]=300&locale=${locale}`)
+        .then(r => r.json())
+        .then(({data}) => {
+          localStorage.setItem(cacheKey, JSON.stringify(data));
+          return data;
+        });
+    }
+
+    const questionText = document.getElementById('questionText');
+    const answersEl = document.getElementById('answers');
+    const explanationEl = document.getElementById('explanation');
+    const nextBtn = document.getElementById('nextBtn');
+
+    let biases = [];
+    let questions = [];
+    let currentAnswer = '';
+    let currentExplanation = '';
+
+    function buildQuestions(data) {
+      data.forEach(b => {
+        let qs = b.content?.questions;
+        if (!qs) return;
+        if (!Array.isArray(qs)) qs = [qs];
+        qs.forEach(q => {
+          let text = '';
+          let exp = '';
+          if (typeof q === 'string') {
+            text = q;
+          } else if (typeof q === 'object' && q) {
+            text = q.question || q.text || '';
+            exp = q.explanation || q.answer || '';
+          }
+          if (text) {
+            questions.push({text, title: b.title, explanation: exp});
+          }
+        });
+      });
+    }
+
+    function shuffle(arr) {
+      for (let i = arr.length - 1; i > 0; i--) {
+        const j = Math.floor(Math.random() * (i + 1));
+        [arr[i], arr[j]] = [arr[j], arr[i]];
+      }
+      return arr;
+    }
+
+    function showQuestion() {
+      nextBtn.classList.add('d-none');
+      explanationEl.textContent = '';
+      answersEl.innerHTML = '';
+
+      const qItem = questions[Math.floor(Math.random() * questions.length)];
+      currentAnswer = qItem.title;
+      currentExplanation = qItem.explanation || '';
+      questionText.textContent = qItem.text;
+
+      const other = biases.filter(b => b.title !== currentAnswer);
+      shuffle(other);
+      const options = [currentAnswer, ...other.slice(0, 3).map(b => b.title)];
+      shuffle(options);
+
+      options.forEach(opt => {
+        const btn = document.createElement('button');
+        btn.className = 'btn btn-outline-primary w-100 text-start';
+        btn.textContent = opt;
+        btn.onclick = () => checkAnswer(btn);
+        answersEl.appendChild(btn);
+      });
+    }
+
+   function checkAnswer(btn) {
+     Array.from(answersEl.children).forEach(b => {
+       b.disabled = true;
+       if (b.textContent === currentAnswer) {
+         b.classList.remove('btn-outline-primary');
+         b.classList.add('btn-success');
+       } else if (b === btn) {
+         b.classList.remove('btn-outline-primary');
+         b.classList.add('btn-danger');
+       }
+     });
+      if (currentExplanation) {
+        explanationEl.textContent = currentExplanation;
+      }
+      nextBtn.classList.remove('d-none');
+    }
+
+    nextBtn.addEventListener('click', showQuestion);
+
+    getBiases()
+      .then(data => {
+        biases = data;
+        buildQuestions(data);
+        if (questions.length) {
+          showQuestion();
+        } else {
+          questionText.textContent = texts[locale].loadError;
+        }
+      })
+      .catch(() => {
+        questionText.textContent = texts[locale].loadError;
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- adjust the quiz markup to stack answers vertically
- handle question objects so the text is shown correctly
- display explanations after selecting an answer

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686b591549b8832794a70bd4d5e7438a