### PR TITLE
Normalize image filenames before encoding

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,13 @@
           const idTrue  = bias.biasId ? bias.biasId - 100 : '';
           const title   = bias.title;
           const descr   = bias.shortDescription || '';
-          const imgName = bias.content?.engTitle?.trim().toLowerCase();
+          const normalizeImgName = (name) =>
+            name
+              ?.trim()
+              .replace(/[\u2013\u2014]/g, '-')   // en/em dash → hyphen
+              .replace(/\s+/g, ' ')             // collapse repeated spaces
+              .toLowerCase();
+          const imgName = normalizeImgName(bias.content?.engTitle);
           const imgSrc  = imgName ? `img/${encodeURIComponent(imgName)}.png` : null;
 
           const col = document.createElement('div');


### PR DESCRIPTION
## Summary
- normalize bias image names by trimming, unifying dash characters, and collapsing spaces before encoding

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692be832ff608327a8897ea02d9575d6)