### PR TITLE
Add exam ticket study trainer

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,269 @@
+const EXAMPLE_TICKETS = [
+  {
+    id: 1,
+    title: 'Основные термины и определения',
+    theme: 'Теория',
+    summary: 'Базовые понятия, которые важно уверенно воспроизводить на экзамене.',
+    question: 'Дай определение ключевому понятию темы и назови его основные признаки.',
+    answer: 'Сформулируй определение своими словами, затем перечисли 3–4 главных признака и коротко поясни каждый.'
+  },
+  {
+    id: 2,
+    title: 'Классификация и структура',
+    theme: 'Теория',
+    summary: 'Удобный билет для повторения списков, классификаций и иерархии понятий.',
+    question: 'Какие основные элементы входят в классификацию по этой теме?',
+    answer: 'Ответ лучше строить по пунктам: назвать каждый элемент, дать короткое описание и указать отличие от остальных.'
+  },
+  {
+    id: 3,
+    title: 'Алгоритм решения задачи',
+    theme: 'Практика',
+    summary: 'Повторение последовательности действий и типичных ошибок.',
+    question: 'Опиши пошаговый алгоритм выполнения задания по теме.',
+    answer: 'Начни с подготовки данных, затем перечисли шаги выполнения, контроль результата и типичные ошибки, которых нужно избегать.'
+  },
+  {
+    id: 4,
+    title: 'Сравнение подходов',
+    theme: 'Анализ',
+    summary: 'Билет на понимание различий между похожими методами или терминами.',
+    question: 'В чём различие между двумя близкими подходами и когда используется каждый из них?',
+    answer: 'Сначала назови общее, затем выдели 2–3 ключевых различия, после чего приведи пример ситуации для каждого подхода.'
+  },
+  {
+    id: 5,
+    title: 'Типовые ошибки и профилактика',
+    theme: 'Практика',
+    summary: 'Полезен для подготовки к устному ответу с примерами.',
+    question: 'Какие типичные ошибки допускают по этой теме и как их предотвратить?',
+    answer: 'Перечисли основные ошибки, объясни их причину и добавь по одной профилактической рекомендации для каждой.'
+  }
+];
+
+const tickets = Array.from({ length: 50 }, (_, index) => {
+  const preset = EXAMPLE_TICKETS[index];
+  if (preset) {
+    return preset;
+  }
+
+  const ticketNumber = index + 1;
+  return {
+    id: ticketNumber,
+    title: `Билет ${ticketNumber}`,
+    theme: ticketNumber % 2 === 0 ? 'Теория' : 'Практика',
+    summary: 'Здесь можно подставить реальное название билета и короткую подсказку по содержанию.',
+    question: `Вставь сюда формулировку вопроса для билета №${ticketNumber}.`,
+    answer: 'Вставь сюда полный ответ, который хочешь повторять перед экзаменом.'
+  };
+});
+
+const state = {
+  viewedTicketIds: new Set(),
+  randomPulls: 0,
+  lastOpenedTicketId: null,
+  currentRandomTicketId: null
+};
+
+const elements = {
+  totalTicketsCount: document.getElementById('totalTicketsCount'),
+  viewedTicketsCount: document.getElementById('viewedTicketsCount'),
+  randomModeCount: document.getElementById('randomModeCount'),
+  openPickerButton: document.getElementById('openPickerButton'),
+  randomTicketButton: document.getElementById('randomTicketButton'),
+  repeatLastTicketButton: document.getElementById('repeatLastTicketButton'),
+  emptyState: document.getElementById('emptyState'),
+  ticketViewer: document.getElementById('ticketViewer'),
+  viewerTicketNumber: document.getElementById('viewerTicketNumber'),
+  viewerTicketTheme: document.getElementById('viewerTicketTheme'),
+  viewerTicketTitle: document.getElementById('viewerTicketTitle'),
+  viewerTicketSummary: document.getElementById('viewerTicketSummary'),
+  viewerTicketQuestion: document.getElementById('viewerTicketQuestion'),
+  viewerTicketAnswer: document.getElementById('viewerTicketAnswer'),
+  toggleViewerAnswerButton: document.getElementById('toggleViewerAnswerButton'),
+  viewerProgressText: document.getElementById('viewerProgressText'),
+  closeViewerButton: document.getElementById('closeViewerButton'),
+  randomTicketNumber: document.getElementById('randomTicketNumber'),
+  randomTicketTitle: document.getElementById('randomTicketTitle'),
+  randomTicketSummary: document.getElementById('randomTicketSummary'),
+  randomTicketQuestion: document.getElementById('randomTicketQuestion'),
+  randomTicketAnswer: document.getElementById('randomTicketAnswer'),
+  showRandomAnswerButton: document.getElementById('showRandomAnswerButton'),
+  nextRandomTicketButton: document.getElementById('nextRandomTicketButton'),
+  ticketPickerModal: document.getElementById('ticketPickerModal'),
+  closePickerButton: document.getElementById('closePickerButton'),
+  ticketSearchInput: document.getElementById('ticketSearchInput'),
+  ticketList: document.getElementById('ticketList')
+};
+
+function updateStats() {
+  elements.totalTicketsCount.textContent = String(tickets.length);
+  elements.viewedTicketsCount.textContent = String(state.viewedTicketIds.size);
+  elements.randomModeCount.textContent = String(state.randomPulls);
+  elements.repeatLastTicketButton.disabled = state.lastOpenedTicketId === null;
+}
+
+function markTicketViewed(ticketId) {
+  state.viewedTicketIds.add(ticketId);
+  state.lastOpenedTicketId = ticketId;
+  updateStats();
+}
+
+function getTicketById(ticketId) {
+  return tickets.find(ticket => ticket.id === ticketId);
+}
+
+function openTicket(ticketId) {
+  const ticket = getTicketById(ticketId);
+  if (!ticket) {
+    return;
+  }
+
+  markTicketViewed(ticket.id);
+  elements.emptyState.classList.add('hidden');
+  elements.ticketViewer.classList.remove('hidden');
+  elements.viewerTicketNumber.textContent = `Билет №${ticket.id}`;
+  elements.viewerTicketTheme.textContent = ticket.theme;
+  elements.viewerTicketTitle.textContent = ticket.title;
+  elements.viewerTicketSummary.textContent = ticket.summary;
+  elements.viewerTicketQuestion.textContent = ticket.question;
+  elements.viewerTicketAnswer.textContent = ticket.answer;
+  elements.viewerTicketAnswer.classList.add('hidden-answer');
+  elements.toggleViewerAnswerButton.textContent = 'Показать ответ';
+  elements.viewerProgressText.textContent = `Открыт билет ${ticket.id} из ${tickets.length}`;
+}
+
+function closeTicketViewer() {
+  elements.ticketViewer.classList.add('hidden');
+  elements.emptyState.classList.remove('hidden');
+}
+
+function toggleViewerAnswer() {
+  const isHidden = elements.viewerTicketAnswer.classList.contains('hidden-answer');
+  elements.viewerTicketAnswer.classList.toggle('hidden-answer', !isHidden);
+  elements.toggleViewerAnswerButton.textContent = isHidden ? 'Скрыть ответ' : 'Показать ответ';
+}
+
+function renderTicketList(filter = '') {
+  const normalizedFilter = filter.trim().toLowerCase();
+  const filteredTickets = tickets.filter(ticket => {
+    const searchableText = `${ticket.id} ${ticket.title} ${ticket.summary} ${ticket.theme}`.toLowerCase();
+    return searchableText.includes(normalizedFilter);
+  });
+
+  if (!filteredTickets.length) {
+    elements.ticketList.innerHTML = '<div class="no-results">Ничего не найдено. Попробуй другой запрос.</div>';
+    return;
+  }
+
+  elements.ticketList.innerHTML = filteredTickets.map(ticket => `
+    <button class="ticket-item" type="button" data-ticket-id="${ticket.id}">
+      <span class="ticket-badge">Билет №${ticket.id}</span>
+      <div class="ticket-item-title">${ticket.title}</div>
+      <p class="ticket-item-summary">${ticket.summary}</p>
+    </button>
+  `).join('');
+}
+
+function openPicker() {
+  elements.ticketPickerModal.classList.remove('hidden');
+  elements.ticketPickerModal.setAttribute('aria-hidden', 'false');
+  renderTicketList(elements.ticketSearchInput.value);
+  elements.ticketSearchInput.focus();
+}
+
+function closePicker() {
+  elements.ticketPickerModal.classList.add('hidden');
+  elements.ticketPickerModal.setAttribute('aria-hidden', 'true');
+}
+
+function getRandomTicket() {
+  if (tickets.length === 0) {
+    return null;
+  }
+
+  const availableTickets = tickets.filter(ticket => ticket.id !== state.currentRandomTicketId);
+  const pool = availableTickets.length ? availableTickets : tickets;
+  const randomIndex = Math.floor(Math.random() * pool.length);
+  return pool[randomIndex];
+}
+
+function showRandomTicket() {
+  const ticket = getRandomTicket();
+  if (!ticket) {
+    return;
+  }
+
+  state.currentRandomTicketId = ticket.id;
+  state.randomPulls += 1;
+  markTicketViewed(ticket.id);
+
+  elements.randomTicketNumber.textContent = `Билет №${ticket.id}`;
+  elements.randomTicketTitle.textContent = ticket.title;
+  elements.randomTicketSummary.textContent = ticket.summary;
+  elements.randomTicketQuestion.textContent = ticket.question;
+  elements.randomTicketAnswer.textContent = ticket.answer;
+  elements.randomTicketAnswer.classList.add('hidden-answer');
+  elements.showRandomAnswerButton.disabled = false;
+  elements.showRandomAnswerButton.textContent = 'Смотреть ответ';
+  elements.nextRandomTicketButton.disabled = true;
+  updateStats();
+}
+
+function revealRandomAnswer() {
+  elements.randomTicketAnswer.classList.remove('hidden-answer');
+  elements.showRandomAnswerButton.textContent = 'Ответ открыт';
+  elements.showRandomAnswerButton.disabled = true;
+  elements.nextRandomTicketButton.disabled = false;
+}
+
+function repeatLastTicket() {
+  if (state.lastOpenedTicketId !== null) {
+    openTicket(state.lastOpenedTicketId);
+  }
+}
+
+function bindEvents() {
+  elements.openPickerButton.addEventListener('click', openPicker);
+  elements.closePickerButton.addEventListener('click', closePicker);
+  elements.randomTicketButton.addEventListener('click', showRandomTicket);
+  elements.showRandomAnswerButton.addEventListener('click', revealRandomAnswer);
+  elements.nextRandomTicketButton.addEventListener('click', showRandomTicket);
+  elements.toggleViewerAnswerButton.addEventListener('click', toggleViewerAnswer);
+  elements.closeViewerButton.addEventListener('click', closeTicketViewer);
+  elements.repeatLastTicketButton.addEventListener('click', repeatLastTicket);
+
+  elements.ticketSearchInput.addEventListener('input', event => {
+    renderTicketList(event.target.value);
+  });
+
+  elements.ticketList.addEventListener('click', event => {
+    const ticketButton = event.target.closest('[data-ticket-id]');
+    if (!ticketButton) {
+      return;
+    }
+
+    openTicket(Number(ticketButton.dataset.ticketId));
+    closePicker();
+  });
+
+  elements.ticketPickerModal.addEventListener('click', event => {
+    if (event.target === elements.ticketPickerModal) {
+      closePicker();
+    }
+  });
+
+  document.addEventListener('keydown', event => {
+    if (event.key === 'Escape' && !elements.ticketPickerModal.classList.contains('hidden')) {
+      closePicker();
+    }
+  });
+}
+
+function init() {
+  updateStats();
+  renderTicketList();
+  bindEvents();
+}
+
+init();

--- a/index.html
+++ b/index.html
@@ -1,200 +1,167 @@
 <!DOCTYPE html>
 <html lang="ru">
 <head>
-  <meta charset="utf-8">
-  <title>Когнитивные искажения</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <!-- Bootstrap -->
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
-  <!-- Custom styles -->
-  <link href="style.css" rel="stylesheet">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Тренажёр экзаменационных билетов</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <!-- Navbar -->
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-    <div class="container">
-      <a class="navbar-brand" href="#"><b>BIAS TRAINER</b></a>
-      <div class="d-flex ms-auto align-items-center">
-        <a id="trainingLink" href="training.html" class="btn btn-outline-light me-2">Тренировка</a>
-        <select id="languageSelect" class="form-select me-2" style="width:auto">
-          <option value="ru">🇷🇺 RU</option>
-          <option value="en">🇬🇧 Eng</option>
-        </select>
-        <input id="searchInput" class="form-control" type="search" placeholder="Поиск…" aria-label="Поиск" style="max-width:270px">
+  <div class="app-shell">
+    <header class="hero">
+      <div>
+        <p class="eyebrow">Подготовка к экзамену</p>
+        <h1>Тренажёр для изучения 50 билетов</h1>
+        <p class="hero-text">
+          Открывай конкретный билет, повторяй ответ целиком или тяни случайный вопрос,
+          чтобы проверить себя в режиме тренировки.
+        </p>
       </div>
-    </div>
-  </nav>
 
-  <div class="container my-4">
-    <h1 class="mb-4" id="pageHeading">Список когнитивных искажений</h1>
-    <!-- Grid: 4 cols on md+ -->
-    <div id="bias-list" class="row g-4"></div>
+      <div class="hero-actions">
+        <button class="primary-button" id="openPickerButton">Выбрать билет</button>
+        <button class="secondary-button" id="randomTicketButton">Тянуть случайный билет</button>
+      </div>
+
+      <div class="hero-stats" aria-label="Статистика тренировки">
+        <article class="stat-card">
+          <span class="stat-value" id="totalTicketsCount">50</span>
+          <span class="stat-label">билетов</span>
+        </article>
+        <article class="stat-card">
+          <span class="stat-value" id="viewedTicketsCount">0</span>
+          <span class="stat-label">просмотрено</span>
+        </article>
+        <article class="stat-card">
+          <span class="stat-value" id="randomModeCount">0</span>
+          <span class="stat-label">случайных вытягиваний</span>
+        </article>
+      </div>
+    </header>
+
+    <main class="layout-grid">
+      <section class="panel panel-large" aria-labelledby="studyModeTitle">
+        <div class="panel-head">
+          <div>
+            <p class="section-kicker">Режим обучения</p>
+            <h2 id="studyModeTitle">Открыть билет и спокойно дочитать</h2>
+          </div>
+          <button class="ghost-button" id="repeatLastTicketButton" disabled>Открыть последний</button>
+        </div>
+
+        <div id="emptyState" class="empty-state">
+          <div class="empty-icon">🎟️</div>
+          <h3>Выбери билет из списка</h3>
+          <p>
+            В списке показываются номер билета, заголовок и короткое описание.
+            После открытия можно читать вопрос, смотреть ответ и закрывать карточку.
+          </p>
+        </div>
+
+        <article id="ticketViewer" class="ticket-viewer hidden" aria-live="polite">
+          <div class="ticket-meta-row">
+            <span class="ticket-badge" id="viewerTicketNumber"></span>
+            <span class="ticket-theme" id="viewerTicketTheme"></span>
+          </div>
+          <h3 id="viewerTicketTitle"></h3>
+          <p class="ticket-note" id="viewerTicketSummary"></p>
+
+          <div class="ticket-section">
+            <h4>Вопрос</h4>
+            <p id="viewerTicketQuestion"></p>
+          </div>
+
+          <div class="ticket-section answer-box" id="viewerAnswerBox">
+            <div class="answer-head">
+              <h4>Ответ</h4>
+              <button class="secondary-button compact-button" id="toggleViewerAnswerButton">Показать ответ</button>
+            </div>
+            <p id="viewerTicketAnswer" class="hidden-answer"></p>
+          </div>
+
+          <div class="ticket-footer">
+            <span id="viewerProgressText"></span>
+            <button class="ghost-button" id="closeViewerButton">Закрыть</button>
+          </div>
+        </article>
+      </section>
+
+      <section class="panel" aria-labelledby="randomModeTitle">
+        <div class="panel-head">
+          <div>
+            <p class="section-kicker">Режим тренировки</p>
+            <h2 id="randomModeTitle">Случайный билет</h2>
+          </div>
+        </div>
+
+        <article class="random-card" id="randomCard">
+          <span class="ticket-badge" id="randomTicketNumber">—</span>
+          <h3 id="randomTicketTitle">Нажми на кнопку, чтобы вытянуть билет</h3>
+          <p class="ticket-note" id="randomTicketSummary">
+            Подойдёт для быстрого самоконтроля перед экзаменом.
+          </p>
+
+          <div class="ticket-section">
+            <h4>Вопрос</h4>
+            <p id="randomTicketQuestion">Сначала выбери режим «Тянуть случайный билет».</p>
+          </div>
+
+          <div class="ticket-section answer-box" id="randomAnswerBox">
+            <div class="answer-head">
+              <h4>Ответ</h4>
+              <button class="secondary-button compact-button" id="showRandomAnswerButton" disabled>Смотреть ответ</button>
+            </div>
+            <p id="randomTicketAnswer" class="hidden-answer">Ответ появится здесь.</p>
+          </div>
+
+          <div class="random-actions">
+            <button class="primary-button" id="nextRandomTicketButton" disabled>Тянуть следующий билет</button>
+          </div>
+        </article>
+      </section>
+
+      <section class="panel suggestions-panel" aria-labelledby="ideasTitle">
+        <div class="panel-head">
+          <div>
+            <p class="section-kicker">Что ещё можно добавить</p>
+            <h2 id="ideasTitle">Идеи для следующей версии</h2>
+          </div>
+        </div>
+
+        <ul class="ideas-list">
+          <li><strong>Избранное:</strong> помечать сложные билеты и повторять только их.</li>
+          <li><strong>Фильтр по темам:</strong> учить отдельно теорию, практику или конкретный раздел.</li>
+          <li><strong>Прогресс:</strong> сохранять, какие билеты уже повторены и сколько раз.</li>
+          <li><strong>Режим самопроверки:</strong> сначала пытаться ответить самому, затем открывать эталон.</li>
+          <li><strong>Таймер:</strong> тренироваться отвечать в условиях, приближённых к экзамену.</li>
+          <li><strong>Импорт из JSON:</strong> быстро подставить свои реальные 50 билетов без правки интерфейса.</li>
+        </ul>
+      </section>
+    </main>
   </div>
 
-  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
-  <script>
-    const searchInput   = document.getElementById('searchInput');
-    const listEl        = document.getElementById('bias-list');
-    const langSelect    = document.getElementById('languageSelect');
-    const trainingLink  = document.getElementById('trainingLink');
-    const htmlTag       = document.documentElement;
+  <div class="modal-overlay hidden" id="ticketPickerModal" aria-hidden="true">
+    <div class="modal-card" role="dialog" aria-modal="true" aria-labelledby="pickerTitle">
+      <div class="modal-head">
+        <div>
+          <p class="section-kicker">Все билеты</p>
+          <h2 id="pickerTitle">Выбери нужный билет</h2>
+        </div>
+        <button class="icon-button" id="closePickerButton" aria-label="Закрыть список билетов">✕</button>
+      </div>
 
-    let locale = localStorage.getItem('lang') || 'ru';
-    langSelect.value = locale;
-    htmlTag.lang = locale;
+      <label class="search-field">
+        <span>Поиск по номеру или заголовку</span>
+        <input id="ticketSearchInput" type="search" placeholder="Например, 12 или «Теория»">
+      </label>
 
-    const localeMap = { ru: 'ru-RU', en: 'en-US' };
-    const defaultApiLocale = 'ru-RU';
-    const apiBase = 'https://cdn.contentful.com/spaces/bczf5h4ng6uk/environments/master/entries';
-    const token   = 'byZhanM7gUzErkI8Kv2Vxq8UfwiRdLcwDEOANav8K7g';
+      <div class="ticket-list" id="ticketList"></div>
+    </div>
+  </div>
 
-    const texts = {
-      ru: {brand:'BIAS TRAINER', heading:'Список когнитивных искажений',
-           search:'Поиск…', training:'Тренировка', error:'Не удалось загрузить данные.'},
-      en: {brand:'Cognitive biases', heading:'List of cognitive biases',
-           search:'Search…', training:'Training', error:'Failed to load data.'}
-    };
-
-    function applyTexts() {
-      const t = texts[locale];
-      document.getElementById('pageHeading').textContent  = t.heading;
-      searchInput.placeholder = t.search;
-      trainingLink.textContent = t.training;
-    }
-    applyTexts();
-
-    langSelect.addEventListener('change', () => {
-      localStorage.setItem('lang', langSelect.value);
-      location.reload();
-    });
-
-    const richTextToString = (rt) => {
-      if (typeof rt === 'string') return rt;
-      const out = [];
-      (rt?.content || []).forEach(block => {
-        const text = (block?.content || [])
-          .map(child => child?.value || '')
-          .join('')
-          .trim();
-        if (text) out.push(text);
-      });
-      return out.join('\n\n');
-    };
-
-    const normalizeArray = (value) => {
-      if (Array.isArray(value)) return value;
-      return value ? [value] : [];
-    };
-
-    const normalizeBias = (item) => {
-      const f = item?.fields || {};
-      const content = f.content || {};
-      const engTitle = content.engTitle || f.engTitle || '';
-      const title = locale === 'en' ? (engTitle || f.title || '') : (f.title || engTitle || '');
-      return {
-        biasId: Number(f.biasId) || null,
-        title,
-        shortDescription: f.shortDescription || content.shortDescription || '',
-        category: f.category || content.category || '',
-        fullDescription: richTextToString(f.fullDescription || content.fullDescription || ''),
-        content: {
-          engTitle,
-          advices: normalizeArray(content.advices || f.advices),
-          examples: normalizeArray(content.examples || f.examples),
-          questions: normalizeArray(content.questions || f.questions),
-          wikipediaLink: content.wikipediaLink || f.wikipediaLink
-        },
-        wikipediaLink: content.wikipediaLink || f.wikipediaLink
-      };
-    };
-
-    function fetchEntries(langCode) {
-      const apiLocale = localeMap[langCode] || defaultApiLocale;
-      const url = `${apiBase}?access_token=${token}&locale=${apiLocale}&limit=1000`;
-      return fetch(url).then(r => r.json()).then(j => j.items || []);
-    }
-
-    async function getBiases() {
-      const key = `biasData_v2_${locale}`;
-      const cached = localStorage.getItem(key);
-      if (cached) {
-        try { return JSON.parse(cached); }
-        catch { localStorage.removeItem(key); }
-      }
-
-      let items = [];
-      try {
-        items = await fetchEntries(locale);
-        if (!items.length && locale !== 'ru') {
-          items = await fetchEntries('ru');
-        }
-      } catch (e) {
-        if (locale !== 'ru') {
-          items = await fetchEntries('ru');
-        } else {
-          throw e;
-        }
-      }
-
-      const normalized = items
-        .map(normalizeBias)
-        .filter(b => b.biasId);
-      if (normalized.length) {
-        localStorage.setItem(key, JSON.stringify(normalized));
-      }
-      return normalized;
-    }
-
-    getBiases()
-      .then(data => {
-        data.sort((a,b) => (a.biasId || 0) - (b.biasId || 0));
-        data.forEach(bias => {
-          const idTrue  = bias.biasId ? bias.biasId - 100 : '';
-          const title   = bias.title;
-          const descr   = bias.shortDescription || '';
-          const normalizeImgName = (name) =>
-            name
-              ?.trim()
-              .replace(/[\u2013\u2014]/g, '-')   // en/em dash → hyphen
-              .replace(/\s+/g, ' ')             // collapse repeated spaces
-              .toLowerCase();
-          const imgName = normalizeImgName(bias.content?.engTitle);
-          const imgSrc  = imgName ? `img/${encodeURIComponent(imgName)}.png` : null;
-
-          const col = document.createElement('div');
-          col.className = 'col-12 col-sm-6 col-md-3 bias-col';
-
-          col.innerHTML = `
-            <div class="card card-tile h-100 d-flex flex-column" data-title="${title.toLowerCase()}">
-              <div class="tile-img-wrap">
-                ${imgSrc
-                  ? `<img src="${imgSrc}"
-                          alt="${title}"
-                          class="tile-img"
-                          loading="lazy"
-                          onerror="this.onerror=null; const d=document.createElement('div'); d.className='tile-img-placeholder'; this.replaceWith(d);">`
-                  : `<div class="tile-img-placeholder"></div>`}
-              </div>
-              <div class="card-body px-3 py-2 d-flex flex-column">
-                <h5 class="card-title mb-1">${idTrue}. ${title}</h5>
-                <p class="card-text mb-0">${descr}</p>
-                <a href="bias.html?biasId=${bias.biasId}" class="stretched-link"></a>
-              </div>
-            </div>`;
-          listEl.appendChild(col);
-        });
-
-        searchInput.addEventListener('input', () => {
-          const q = searchInput.value.trim().toLowerCase();
-          listEl.querySelectorAll('.bias-col').forEach(col => {
-            const title = col.querySelector('.card').dataset.title;
-            col.classList.toggle('hidden', !title.includes(q));
-          });
-        });
-      })
-      .catch(() => {
-        listEl.innerHTML = `<p class="text-danger">${texts[locale].error}</p>`;
-      });
-  </script>
+  <script src="app.js"></script>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -1,290 +1,421 @@
-/* ----------  Apple-inspired базовые стили  ---------- */
-html, body {
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI",
-               Roboto, "Helvetica Neue", Arial, sans-serif;
-  background-color: #f5f5f7;
-  color: #1d1d1f;
-  scroll-behavior: smooth;
+:root {
+  --bg: #f4f7fb;
+  --surface: rgba(255, 255, 255, 0.88);
+  --surface-solid: #ffffff;
+  --text: #172033;
+  --muted: #61708a;
+  --primary: #4f46e5;
+  --primary-dark: #3730a3;
+  --primary-soft: rgba(79, 70, 229, 0.12);
+  --border: rgba(23, 32, 51, 0.1);
+  --shadow: 0 24px 60px rgba(28, 39, 74, 0.12);
+  --radius-xl: 28px;
+  --radius-lg: 20px;
+  --radius-md: 14px;
 }
 
-.navbar-brand {
-  font-weight: 600;
-  letter-spacing: -0.02em;
+* {
+  box-sizing: border-box;
 }
 
-/* ----------  Навбар / формы  ---------- */
-#searchInput {
-  max-width: 500px;
-  border-radius: 2rem;
-  padding-left: 1.25rem;
-}
-#languageSelect {
-  min-width: 110px;
-  margin-right: 0.5rem;
-}
-
-/* ----------  Общие карточки  ---------- */
-.card {
-  border: none;
-  border-radius: 1rem;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.08);
-  transition: transform .2s ease, box-shadow .2s ease;
-}
-.card:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 6px 16px rgba(0,0,0,0.12);
-}
-
-.card-title {
-  font-size: 1.1rem;
-  font-weight: 600;
-  margin-bottom: .25rem;
-}
-.card-text {
-  color: #3a3a3c;
-}
-
-.bias-col.hidden {
-  display: none !important;
-}
-
-/* ----------  Плитки на главной  ---------- */
-.card-tile {
-  display: flex;
-  flex-direction: column;
-  background: #fff;
-  height: 100%;
-}
-.tile-img-wrap {
-  width: 100%;
-  padding-top: 100%; /* 16:9 ratio box */
-  position: relative;
-  overflow: hidden;
-  border-top-left-radius: 1rem;
-  border-top-right-radius: 1rem;
-}
-.tile-img,
-.tile-img-placeholder {
-  position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  object-fit: cover;
-}
-.tile-img-placeholder {
-  background-color: #ddd;
-}
-
-/* ----------  Страница искажения  ---------- */
-.bias-article {
-  max-width: 72ch;
-  margin: 0 auto;
-}
-.article-img {
-  width: 100%;
-  object-fit: cover;
-  border-radius: 1rem;
-}
-
-/* ----------  Блок советов (если понадобится)  ---------- */
-.advice {
-  background-color: #e9ecef;
-  border-radius: .5rem;
-  padding: .75rem 1rem;
-}
-
-/* ====== Стиль страницы тренировки (Apple-like) ====== */
-.quiz-body {
-  background: radial-gradient(1000px 600px at 20% -10%, rgba(123, 92, 255, .08), transparent 60%),
-              radial-gradient(900px 700px at 110% 10%, rgba(91, 140, 250, .10), transparent 60%),
-              linear-gradient(180deg, #f7f8fb 0%, #f1f3f8 100%);
+body {
+  margin: 0;
   min-height: 100vh;
-}
-
-.quiz-card {
-  border: none;
-  border-radius: 24px;
-  background: rgba(255,255,255,0.88);
-  backdrop-filter: saturate(120%) blur(6px);
-  box-shadow: 0 20px 50px rgba(16, 24, 40, 0.08);
-}
-
-@media (prefers-color-scheme: dark) {
-  .quiz-body {
-    background: radial-gradient(900px 600px at 20% -10%, rgba(123, 92, 255, .15), transparent 60%),
-                radial-gradient(800px 600px at 110% 10%, rgba(91, 140, 250, .18), transparent 60%),
-                linear-gradient(180deg, #0e1116 0%, #0a0d12 100%);
-  }
-  .quiz-card {
-    background: rgba(16, 18, 24, 0.75);
-    box-shadow: 0 18px 48px rgba(0,0,0,.5);
-  }
-}
-
-/* Вопрос */
-#questionText {
-  line-height: 1.45;
-}
-
-/* Базовая градиентная кнопка ответа */
-.btn-gradient {
-  border: none !important;
-  border-radius: 14px;
-  color: #fff !important;
-  background: linear-gradient(135deg, #5b8cfa, #7a5cff);
-  box-shadow: 0 8px 24px rgba(123,92,255,.20);
-  transition: transform .15s ease, box-shadow .2s ease, opacity .2s ease, filter .2s ease;
-}
-
-.btn-gradient:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 32px rgba(123,92,255,.28);
-}
-
-.btn-gradient:active {
-  transform: translateY(0);
-  box-shadow: 0 6px 18px rgba(123,92,255,.35);
-}
-
-.answer-btn {
-  font-weight: 600;
-  letter-spacing: .2px;
-  padding: 14px 16px;
-}
-
-.answer-btn:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 4px rgba(91,140,250,.25);
-}
-
-.answer-btn:disabled {
-  cursor: default;
-  opacity: .96;
-}
-
-/* Состояния после выбора */
-.answer-correct {
-  border: none !important;
-  color: #fff !important;
-  background: linear-gradient(135deg, #22c55e, #16a34a) !important; /* зелёный */
-  box-shadow: 0 10px 28px rgba(34,197,94,.28);
-  transform: translateY(-1px);
-}
-
-.answer-wrong {
-  border: none !important;
-  color: #fff !important;
-  background: linear-gradient(135deg, #ef4444, #dc2626) !important; /* красный */
-  box-shadow: 0 10px 28px rgba(239,68,68,.28);
-}
-
-.answer-dim {
-  filter: saturate(.7) brightness(.98);
-  opacity: .9;
-}
-
-/* Кнопка "Следующий вопрос" */
-.btn-next {
-  border-radius: 14px;
-  font-weight: 700;
-  letter-spacing: .2px;
-  padding: 14px 16px;
-}
-
-/* Область пояснения */
-.explanation {
-  border-radius: 16px;
-  padding: 14px 16px;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: var(--text);
   background:
-    linear-gradient(#fff, #fff) padding-box,
-    linear-gradient(135deg, rgba(123,92,255,.35), rgba(91,140,250,.35)) border-box;
-  border: 1.5px solid transparent;
-  color: #23262b;
+    radial-gradient(circle at top left, rgba(99, 102, 241, 0.18), transparent 28%),
+    radial-gradient(circle at top right, rgba(16, 185, 129, 0.12), transparent 24%),
+    var(--bg);
 }
 
-@media (prefers-color-scheme: dark) {
-  .explanation {
-    background:
-      linear-gradient(rgba(18,20,26,.85), rgba(18,20,26,.85)) padding-box,
-      linear-gradient(135deg, rgba(123,92,255,.45), rgba(91,140,250,.45)) border-box;
-    color: #e8eaee;
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+h1,
+h2,
+h3,
+h4,
+p {
+  margin-top: 0;
+}
+
+.app-shell {
+  width: min(1200px, calc(100% - 32px));
+  margin: 0 auto;
+  padding: 32px 0 48px;
+}
+
+.hero,
+.panel,
+.modal-card,
+.ticket-item {
+  backdrop-filter: blur(16px);
+}
+
+.hero,
+.panel {
+  background: var(--surface);
+  border: 1px solid rgba(255, 255, 255, 0.65);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow);
+}
+
+.hero {
+  padding: 36px;
+  margin-bottom: 24px;
+}
+
+.eyebrow,
+.section-kicker {
+  margin-bottom: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.76rem;
+  font-weight: 700;
+  color: var(--primary);
+}
+
+.hero h1 {
+  max-width: 12ch;
+  margin-bottom: 16px;
+  font-size: clamp(2.25rem, 4vw, 4.5rem);
+  line-height: 0.95;
+}
+
+.hero-text {
+  max-width: 60ch;
+  margin-bottom: 24px;
+  color: var(--muted);
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.hero-actions,
+.random-actions,
+.ticket-footer,
+.answer-head,
+.modal-head,
+.panel-head,
+.ticket-meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.hero-actions {
+  flex-wrap: wrap;
+  margin-bottom: 28px;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button,
+.icon-button {
+  border: 0;
+  border-radius: 999px;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, background 0.18s ease, opacity 0.18s ease;
+}
+
+.primary-button,
+.secondary-button,
+.ghost-button {
+  padding: 14px 22px;
+  font-weight: 700;
+}
+
+.primary-button {
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary), #7c3aed);
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.24);
+}
+
+.secondary-button {
+  color: var(--primary);
+  background: var(--primary-soft);
+}
+
+.ghost-button,
+.icon-button {
+  color: var(--text);
+  background: rgba(255, 255, 255, 0.72);
+  border: 1px solid var(--border);
+}
+
+.primary-button:hover,
+.secondary-button:hover,
+.ghost-button:hover,
+.icon-button:hover {
+  transform: translateY(-2px);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
+  transform: none;
+  box-shadow: none;
+}
+
+.compact-button {
+  padding: 10px 16px;
+}
+
+.hero-stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.stat-card,
+.ticket-section,
+.empty-state,
+.random-card,
+.ticket-viewer,
+.ticket-item,
+.search-field input {
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(255, 255, 255, 0.8);
+}
+
+.stat-card {
+  padding: 20px;
+  border-radius: var(--radius-lg);
+}
+
+.stat-value {
+  display: block;
+  margin-bottom: 6px;
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 800;
+}
+
+.stat-label,
+.ticket-note,
+.ticket-theme,
+#viewerProgressText,
+.search-field span {
+  color: var(--muted);
+}
+
+.layout-grid {
+  display: grid;
+  grid-template-columns: 1.35fr 0.95fr;
+  gap: 24px;
+}
+
+.panel {
+  padding: 28px;
+}
+
+.panel-large {
+  min-height: 100%;
+}
+
+.suggestions-panel {
+  grid-column: 1 / -1;
+}
+
+.empty-state,
+.random-card,
+.ticket-viewer {
+  border-radius: var(--radius-lg);
+  padding: 24px;
+}
+
+.empty-state {
+  display: grid;
+  justify-items: start;
+  gap: 12px;
+}
+
+.empty-icon {
+  display: grid;
+  place-items: center;
+  width: 64px;
+  height: 64px;
+  border-radius: 20px;
+  background: var(--primary-soft);
+  font-size: 1.8rem;
+}
+
+.ticket-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  width: fit-content;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.1);
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+
+.ticket-section {
+  margin-top: 18px;
+  border-radius: 18px;
+  padding: 18px;
+}
+
+.ticket-section h4 {
+  margin-bottom: 10px;
+}
+
+.answer-box {
+  border: 1px dashed rgba(79, 70, 229, 0.3);
+}
+
+.ticket-footer,
+.random-actions {
+  margin-top: 20px;
+}
+
+.hidden,
+.hidden-answer {
+  display: none;
+}
+
+.random-card {
+  min-height: 100%;
+}
+
+.ideas-list {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 12px;
+  line-height: 1.65;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 20px;
+  background: rgba(10, 18, 37, 0.45);
+}
+
+.modal-card {
+  width: min(920px, 100%);
+  max-height: min(86vh, 860px);
+  overflow: hidden;
+  padding: 24px;
+  border-radius: var(--radius-xl);
+  background: rgba(255, 255, 255, 0.96);
+  box-shadow: 0 30px 80px rgba(10, 18, 37, 0.28);
+}
+
+.icon-button {
+  width: 42px;
+  height: 42px;
+  font-size: 1rem;
+}
+
+.search-field {
+  display: grid;
+  gap: 8px;
+  margin: 20px 0;
+}
+
+.search-field input {
+  width: 100%;
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 14px 16px;
+  outline: none;
+}
+
+.search-field input:focus {
+  border-color: rgba(79, 70, 229, 0.5);
+  box-shadow: 0 0 0 4px rgba(79, 70, 229, 0.08);
+}
+
+.ticket-list {
+  display: grid;
+  gap: 14px;
+  max-height: calc(86vh - 180px);
+  overflow: auto;
+  padding-right: 4px;
+}
+
+.ticket-item {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 18px;
+  text-align: left;
+}
+
+.ticket-item:hover {
+  border-color: rgba(79, 70, 229, 0.35);
+  box-shadow: 0 12px 24px rgba(28, 39, 74, 0.08);
+}
+
+.ticket-item-title {
+  margin: 10px 0 8px;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.ticket-item-summary {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.55;
+}
+
+.no-results {
+  padding: 24px;
+  text-align: center;
+  color: var(--muted);
+}
+
+@media (max-width: 960px) {
+  .layout-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
   }
 }
 
-/* ====== Анимации ====== */
-.fade-in {
-  animation: fadeInUp .45s ease both;
-}
-@keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(8px); }
-  to   { opacity: 1; transform: translateY(0); }
-}
+@media (max-width: 640px) {
+  .app-shell {
+    width: min(100% - 20px, 1200px);
+    padding-top: 20px;
+  }
 
-.pop {
-  animation: pop .22s ease-in-out;
-}
-@keyframes pop {
-  0%   { transform: scale(1); }
-  50%  { transform: scale(0.985); }
-  100% { transform: scale(1.015); }
-}
+  .hero,
+  .panel,
+  .modal-card {
+    padding: 20px;
+  }
 
-/* === OVERRIDES === */
-/* Анимация появления в 2 раза медленнее */
-.fade-in { animation: fadeInUp .9s ease both; }
+  .hero h1 {
+    max-width: none;
+  }
 
-/* Минималистичные неправильные/прочие варианты: белый фон + лёгкая тень */
-.answer-dim,
+  .panel-head,
+  .hero-actions,
+  .answer-head,
+  .ticket-footer,
+  .modal-head,
+  .ticket-meta-row,
+  .random-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
 
-/* Выбранный неправильный — с едва заметным красным акцентом по границе/тени */
-.answer-wrong {
-  border-color: rgba(239,68,68,.28) !important;
-  /* box-shadow: 0 8px 18px rgba(239,68,68,.12); */
-}
-
-/* Радостная анимация для правильного ответа */
-.answer-correct {
-  border: none !important;
-  color: #fff !important;
-  background: linear-gradient(135deg, #22c55e, #16a34a) !important;
-  box-shadow: 0 12px 34px rgba(34,197,94,.28);
-  transform: translateY(-1px);
-}
-
-/* Праздничный эффект: мягкий свечение + лёгкий бёрст */
-.celebrate {
-  position: relative;
-  animation: successPulse .6s ease-out both;
-}
-.celebrate::after {
-  content: "";
-  position: absolute;
-  inset: -4px;
-  border-radius: 16px;
-  background: radial-gradient(circle at center, rgba(34,197,94,.35), transparent 60%);
-  opacity: 0;
-  animation: burst .6s ease-out .05s both;
-  pointer-events: none;
-}
-
-/* === Animations === */
-@keyframes successPulse {
-  0%   { transform: scale(1);   box-shadow: 0 12px 34px rgba(34,197,94,.22); }
-  40%  { transform: scale(1.03);box-shadow: 0 18px 42px rgba(34,197,94,.32); }
-  100% { transform: scale(1);   box-shadow: 0 12px 34px rgba(34,197,94,.28); }
-}
-@keyframes burst {
-  0%   { opacity: .7; transform: scale(.6); }
-  100% { opacity: 0;  transform: scale(1.25); }
-}
-
-.shake {
-  animation: shake .28s ease-in-out both;
-}
-@keyframes shake {
-  0%   { transform: translateX(0); }
-  20%  { transform: translateX(-7px); }
-  40%  { transform: translateX(6px); }
-  60%  { transform: translateX(-4px); }
-  80%  { transform: translateX(3px); }
-  100% { transform: translateX(0); }
+  .primary-button,
+  .secondary-button,
+  .ghost-button {
+    width: 100%;
+  }
 }


### PR DESCRIPTION
### Motivation
- Replace the previous landing/feature page with a focused, standalone trainer for studying exam tickets that supports both reading individual tickets and fast random drills.
- Provide a simple local data structure with 50 starter tickets so the app works out-of-the-box and can be quickly customized or imported later.

### Description
- Replace `index.html` with a new app shell that includes hero actions, a ticket picker modal, a detailed ticket viewer (question + hidden answer), a random-ticket training card, and a suggestions panel for future features.
- Add `app.js` which implements ticket data (50 tickets, first 5 populated as examples), picker search and render logic, open/close viewer behavior, answer toggle, random pull flow, and lightweight state tracking for viewed tickets and random pulls.
- Update `style.css` with a new responsive design (hero, panels, modal, buttons, stats cards, mobile breakpoints) and visual polish for the new UI.
- Include basic accessibility and UX improvements such as `aria-live` and `aria-hidden` attributes, keyboard `Escape` to close the picker, focus handling, and disabled/enabled states for action buttons.

### Testing
- Ran `node --check app.js` which completed without syntax errors.
- Ran `git diff --check` to verify no whitespace/format issues and it returned no problems.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab6756c808327bcf1b5524745fdf7)